### PR TITLE
Ignore events during executing builds

### DIFF
--- a/src/on-change.go
+++ b/src/on-change.go
@@ -20,6 +20,11 @@ func RunOnChange(build *Build) func(*WatchEvent) {
 }
 
 func DebounceExecution(build *Build) {
+	if (build.Started && !build.Done) {
+		log.Info("Event ignored due to executing build")
+		return
+	}
+	
 	if timer != nil {
 		<-timer.C
 		timer = nil


### PR DESCRIPTION
I am working on a project that has a javascript build compile step. It was throwing events during the build phase that were not excludable with `-e`. This pull request simply ignores events that are emitted after a command is `Started` but before it is `Done`.