### PR TITLE
Remove go install error : errStdout and errStderr declared and not used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/OVYA/yolo
+
+go 1.20
+
+require (
+	github.com/azer/logger v1.0.0
+	github.com/azer/yolo v0.0.0-20200421082124-9f74cacbc50c
+	github.com/fsnotify/fsnotify v1.6.0
+	github.com/gorilla/websocket v1.5.0
+)
+
+require (
+	github.com/azer/is-terminal v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/azer/is-terminal v1.0.0 h1:COvj8jmg2xMz0CqHn4Uu8X1m7Dmzmu0CpciBaLtJQBg=
+github.com/azer/is-terminal v1.0.0/go.mod h1:5geuIpRQvdv6g/Q1MwXHbmNUlFLg8QcheGk4dZOmxQU=
+github.com/azer/logger v1.0.0 h1:3T4BnTLyndJWHajOyECt2kAhnvP30KCrVAkYcMjHrXk=
+github.com/azer/logger v1.0.0/go.mod h1:iaDID7UeBTyUh31bjGFlLkr87k23z/mHMMLzt6YQQHU=
+github.com/azer/yolo v0.0.0-20200421082124-9f74cacbc50c h1:x4m/FfaAsQqLZxKNzpSVaVPP79g91yg1cbRpc0aK4Yo=
+github.com/azer/yolo v0.0.0-20200421082124-9f74cacbc50c/go.mod h1:STi2LrClOuieEG7rszDymhqSV0pEVo2Aaf8+jwIAF2g=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/src/cli.go
+++ b/src/cli.go
@@ -24,7 +24,6 @@ func ExecuteCommand(command string) (string, string, error) {
 		return "", "", err
 	}
 
-	var errStdout, errStderr error
 	stdout := io.MultiWriter(os.Stdout, &stdoutBuf)
 	stderr := io.MultiWriter(os.Stderr, &stderrBuf)
 
@@ -33,11 +32,11 @@ func ExecuteCommand(command string) (string, string, error) {
 	}
 
 	go func() {
-		_, errStdout = io.Copy(stdout, stdoutIn)
+		_, _ = io.Copy(stdout, stdoutIn)
 	}()
 
 	go func() {
-		_, errStderr = io.Copy(stderr, stderrIn)
+		_, _ = io.Copy(stderr, stderrIn)
 	}()
 
 	if err := cmd.Wait(); err != nil {
@@ -47,7 +46,6 @@ func ExecuteCommand(command string) (string, string, error) {
 	outStr, errStr := string(stdoutBuf.Bytes()), string(stderrBuf.Bytes())
 
 	return outStr, errStr, nil
-
 }
 
 func CurrentGitBranch() string {

--- a/yolo.go
+++ b/yolo.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"text/template"
 
-	"github.com/azer/yolo/src"
+	yolo "github.com/OVYA/yolo/src"
 )
 
 func main() {


### PR DESCRIPTION
Fixe this problem and make this package a `go module`.

```
>  go install github.com/azer/yolo@latest
go: finding module for package github.com/gorilla/websocket
go: finding module for package github.com/azer/logger
go: finding module for package github.com/fsnotify/fsnotify
go: found github.com/azer/logger in github.com/azer/logger v1.0.0
go: found github.com/fsnotify/fsnotify in github.com/fsnotify/fsnotify v1.6.0
go: found github.com/gorilla/websocket in github.com/gorilla/websocket v1.5.0
# github.com/azer/yolo/src
code/go/pkg/mod/github.com/azer/yolo@v0.0.0-20200421082124-9f74cacbc50c/src/cli.go:27:6: errStdout declared and not used
code/go/pkg/mod/github.com/azer/yolo@v0.0.0-20200421082124-9f74cacbc50c/src/cli.go:27:17: errStderr declared and not used
```